### PR TITLE
Ignore Info.plist when pulling in pod source files

### DIFF
--- a/Pluralize.swift.podspec
+++ b/Pluralize.swift.podspec
@@ -28,6 +28,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.source_files = 'Pluralize/*'
+  s.exclude_files = 'Pluralize/*.plist'
   s.resource_bundles = {
     'Pluralize.swift' => ['Pod/Assets/*.png']
   }

--- a/Pluralize.swift.podspec
+++ b/Pluralize.swift.podspec
@@ -27,7 +27,7 @@ Pod::Spec.new do |s|
   s.platform     = :ios, '8.0'
   s.requires_arc = true
 
-  s.source_files = 'Pluralize/*'
+  s.source_files = 'Pluralize/!(*.plist)'
   s.resource_bundles = {
     'Pluralize.swift' => ['Pod/Assets/*.png']
   }

--- a/Pluralize.swift.podspec
+++ b/Pluralize.swift.podspec
@@ -27,7 +27,7 @@ Pod::Spec.new do |s|
   s.platform     = :ios, '8.0'
   s.requires_arc = true
 
-  s.source_files = 'Pluralize/!(*.plist)'
+  s.source_files = 'Pluralize/*'
   s.resource_bundles = {
     'Pluralize.swift' => ['Pod/Assets/*.png']
   }


### PR DESCRIPTION
Info.plist was showing up in the source files twice, which caused a build failure with the new Xcode 10 new build system. This PR ensures that the Info.plist is removed when bringing in the library files using CocoaPods. The Info.plist in question is there for running the Pluralize example project only.

Big thanks to @LaurentShala for helping find the fix!